### PR TITLE
support PM_GROUP env for detect worker group name

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -111,10 +111,14 @@ var _workerPair = function (argv, options, name) {
   var _command  = argv.join(' ');
   var _execpath = argv.shift();
   var _newChild = function () {
-    
+    var env = {};
+    for (var k in process.env) {
+      env[k] = process.env[k];
+    }
+    env.PM_GROUP = groupName;
     var sub = child_process.fork(_execpath, argv, {
-      'cwd' : process.cwd(),
-        'env' : process.env,
+      cwd: process.cwd(),
+      env: env,
     });
     var pid = sub.pid;
 
@@ -513,7 +517,7 @@ exports.create  = function (options) {
         setTimeout(function () {
           process.exit(0);
         }, 1000);
-      });
+      }, 'SIGTERM');
     });
 
     process.on('SIGUSR1', function () {

--- a/test/cluster.test.js
+++ b/test/cluster.test.js
@@ -230,10 +230,11 @@ describe('node-cluster v2.0.0-alpha', function() {
     // wait process to listen
     setTimeout(function () {
       HttpRequest(11234, '/sdew/dfewf?dfewf', 'aabb=cdef', function(data) {
-        data.toString().should.eql(JSON.stringify({
+        JSON.parse(data).should.eql({
           'url'   : '/sdew/dfewf?dfewf',
           'data'  : 'aabb=cdef',
-        }));
+          PM_GROUP: 'http1'
+        });
         done();
       });
     }, 500);
@@ -246,7 +247,6 @@ describe('node-cluster v2.0.0-alpha', function() {
     ProcessIds(__dirname + '/fixtures/echo.js', function(error, ids) {
       should.ok(!error);
       ids.length.should.eql(1);
-
       var pid1  = ids.pop();
       process.kill(pid1, 'SIGKILL');
       setTimeout(function() {

--- a/test/fixtures/http.js
+++ b/test/fixtures/http.js
@@ -47,6 +47,7 @@ var server  = require('http').createServer(function (req, res) {
     res.writeHead(200, {'Content-Type': 'text/plain;charset=utf-8'});
     res.end(JSON.stringify({
       'url' : req.url,
+      'PM_GROUP' : process.env.PM_GROUP, 
       'data': chunk.join().toString(),
     }));
   });


### PR DESCRIPTION
When different group worker manager by same master, and they share the same logic code, we need to detect what kind of worker it is.
