### PR TITLE
新增下子进程依次串行启动模式

### DIFF
--- a/demo/master.js
+++ b/demo/master.js
@@ -21,7 +21,7 @@ app.register('error', __dirname + '/worker/exception.js', {
  */
 app.register('daemon', __dirname + '/worker/daemon.js', {
   'trace_gc': true,
-  'children': 2,
+  'children': 2
 });
 
 /**
@@ -30,6 +30,14 @@ app.register('daemon', __dirname + '/worker/daemon.js', {
 app.register('http', __dirname + '/worker/http.js', {
   'listen' : [ 33749, __dirname + '/http.socket' ],
   'children' : 1
+});
+
+/**
+ * process serial start
+ */
+app.register('serial', __dirname + '/worker/serial.js', {
+  'children': 2,
+  'use_serial_mode': true
 });
 
 app.dispatch();

--- a/demo/worker/serial.js
+++ b/demo/worker/serial.js
@@ -1,0 +1,6 @@
+/* vim: set expandtab tabstop=2 shiftwidth=2 foldmethod=marker: */
+
+var worker = require(__dirname + '/../../').createWorker().serialStart(function(done){
+  console.log('child start!');
+  done();
+}, 100).ready();

--- a/lib/child.js
+++ b/lib/child.js
@@ -46,7 +46,8 @@ exports.create = function (argv, options) {
     'children' : CPUS,
     'max_fatal_restart' : 5,
     'pause_after_fatal' : 60000,
-    'max_heartbeat_lost' : -1
+    'max_heartbeat_lost' : -1,
+    'use_serial_mode' : false
   }, options);
 
   if (!_options.children) {
@@ -90,6 +91,14 @@ exports.create = function (argv, options) {
      */
     this.pfatals = [];
 
+    /**
+     * @ 串行启动模式下的获得令牌的进程id及分配过的令牌次数
+     */
+    if (_options.use_serial_mode){
+      this.token_pid = -1;
+      this.token_count = 0;
+    }
+    
   };
   util.inherits(Child, Emitter);
 
@@ -155,10 +164,33 @@ exports.create = function (argv, options) {
           return;
         }
       }
+      
+      // 串行启动模式下发送令牌后，子进程异常退出的情况
+      if (_options.use_serial_mode && _self.token_pid === pid){
+        _self.token_pid = -1;
+      }
+
       _self.start();
     });
 
     sub.on('message', function (msg) {
+      //并行启动的令牌发放及回收操作
+      if (_options.use_serial_mode){
+        if (msg.cmd === 'token_get')
+          try{
+            if (_self.token_pid === -1){
+              sub.send({ token: ++_self.token_count });
+              _self.token_pid = msg.pid;
+            }
+            else{
+              sub.send({ token: -1 });
+            }
+          } catch (e) {}
+        else if (msg.cmd === 'token_release'){
+          _self.token_pid = -1;
+        }
+      }
+
       if (!msg || !msg.type) {
         return;
       }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -146,6 +146,48 @@ exports.create = function (options, PROCESS) {
   };
   /* }}} */
 
+
+  /* {{{ public prototype serialStart() */
+  /**
+   * serial start child Process
+   */
+  Worker.prototype.serialStart = function (fn, serial_mode_get_token_timeout) {
+    var timeout = serial_mode_get_token_timeout || 100;
+    var ctimer;
+    var child_pid = PROCESS.pid;
+    var _self = this;
+
+    if (!fn || typeof fn !== 'function') return;
+
+    PROCESS.on('message', function(tokenRes){
+      //此处有个bug，有时候无法正常进行定时获取令牌的操作，需要加入一个setTimeout解决该问题
+      setTimeout(function(){
+        if (tokenRes.token >= 0){
+          clearTimeout(ctimer);
+          try{
+            fn.call(_self, releaseToken);
+          } catch (e) {}
+        }
+        else{
+          ctimer = setTimeout(function(){
+            try{
+              PROCESS.send({ cmd: 'token_get', pid: child_pid });
+            } catch (e) {}
+          }, timeout);
+        }
+      }, 0);
+    });
+    try{
+      PROCESS.send({ cmd: 'token_get', pid: child_pid });
+    } catch (e) {}
+    return _self;
+  };
+  /* }}} */
+
+  var releaseToken = function(){
+    PROCESS.send({ cmd: 'token_release' });
+  }
+
   var _me = new Worker();
 
   PROCESS.on('SIGHUB',  function () {});

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -163,4 +163,35 @@ describe('worker process', function () {
   });
   /* }}} */
 
+  /* {{{ should_serialStart_works_fine() */
+  it('should_serialStart_works_fine', function (_done) {
+
+    var _me = worker.create({
+      'heartbeat_interval' : 1000,
+      'terminate_timeout'  : 20,
+    }, PROCESS);
+
+    var test = '';
+    var get_token_timeout = 100;
+
+    _me.serialStart(function(done){      
+      test = 'child start!';
+      done();
+    }, get_token_timeout);
+
+    PROCESS.emit('message', {'token': -1});
+
+    setTimeout(function(){
+      test.should.eql('');
+
+      PROCESS.emit('message', {'token': 1});
+
+      setTimeout(function(){
+        test.should.eql('child start!');
+        _done();
+      }, 10);
+    }, get_token_timeout + 1);
+  });
+  /* }}} */
+
 });


### PR DESCRIPTION
1. 在child.js增加一个串行启动模式属性use_serial_mode，当其为true的时候，主进程会监听子进程的请求，并进行令牌的发放回收操作
2. 在worker.js中，新增串行函数Worker.prototype.serialStart，向主进程发送令牌请求，拿到令牌后，启动相应的进程内容。没拿到的会持续向主进程发送请求。另外新增一个releaseToken函数，用于子进程完全启动后，调用该方法，归还令牌
3. 补全相应的测试case，保证覆盖率100%
