### PR TITLE
Support worker.disconnect() and master.fork(name) API. fixes #32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,21 @@
 TESTS = test/*.test.js
 REPORTER = spec
 TIMEOUT = 5000
-JSCOVERAGE = ./node_modules/visionmedia-jscoverage/jscoverage --encoding=utf-8
-MOCHA = ./node_modules/mocha/bin/mocha
+JSCOVERAGE = ./node_modules/jscover/bin/jscover
 
-test:
+install:
 	@npm install
-	@rm -f test/*.socket
-	@$(MOCHA) --reporter $(REPORTER) --timeout $(TIMEOUT) $(MOCHA_OPTS) $(TESTS)
 
-cov:
-	@npm install
-	@-rm -rf lib.bak
-	@-mv -f lib lib.bak
-	$(JSCOVERAGE) lib.bak lib
-	-$(MOCHA) --reporter html-cov --timeout $(TIMEOUT) $(MOCHA_OPTS) $(TESTS) > ./coverage.html
-	@-rm -rf lib && mv -f lib.bak lib
+test: install
+	@NODE_ENV=test ./node_modules/mocha/bin/mocha \
+		--reporter $(REPORTER) \
+		--timeout $(TIMEOUT) \
+		$(TESTS)
 
+cov: install
+	@rm -rf ./lib-cov coverage.html
+	@$(JSCOVERAGE) lib lib-cov
+	@PM_COV=1 $(MAKE) test REPORTER=dot
+	@PM_COV=1 $(MAKE) test REPORTER=html-cov > coverage.html
+	
 .PHONY: test

--- a/demo/graceful_exit/app.js
+++ b/demo/graceful_exit/app.js
@@ -1,0 +1,28 @@
+/*!
+ * pm - demo/graceful_exit/app.js
+ * Copyright(c) 2013 fengmk2 <fengmk2@gmail.com>
+ * MIT Licensed
+ */
+
+"use strict";
+
+/**
+ * Module dependencies.
+ */
+
+var http = require('http');
+
+var server = http.createServer(function (req, res) {
+  if (req.url === '/asyncerror') {
+    setTimeout(function () {
+      asyncError();
+    }, 10);
+    return;
+  }
+  res.end(JSON.stringify({
+    url: req.url,
+    pid: process.pid,
+  }));
+});
+
+module.exports = server;

--- a/demo/graceful_exit/dispatch.js
+++ b/demo/graceful_exit/dispatch.js
@@ -1,0 +1,44 @@
+/*!
+ * pm - demo/graceful_exit/dispatch.js
+ * Copyright(c) 2013 fengmk2 <fengmk2@gmail.com>
+ * MIT Licensed
+ */
+
+"use strict";
+
+/**
+ * Module dependencies.
+ */
+
+var pm = require('../../');
+
+var master = pm.createMaster();
+
+master.on('giveup', function (name, fatals, pause) {
+  console.log('[%s] [master:%s] giveup to restart "%s" process after %d times. pm will try after %d ms.', 
+    new Date(), process.pid, name, fatals, pause);
+});
+
+master.on('disconnect', function (name, pid) {
+  // console.log('%s %s disconnect', name, pid)
+  var w = master.fork(name);
+  console.error('[%s] [master:%s] worker:%s disconnect! new worker:%s fork', 
+    new Date(), process.pid, pid, w.process.pid);
+});
+
+master.on('fork', function (name, pid) {
+  console.log('[%s] [master:%s] new %s:worker:%s fork',
+    new Date(), process.pid, name, pid);
+});
+
+master.on('quit', function (name, pid, code, signal) {
+  console.log('[%s] [master:%s] %s:worker:%s quit, code: %s, signal: %s',
+    new Date(), process.pid, name, pid, code, signal);
+});
+
+master.register('web', __dirname + '/worker.js', {
+  listen: 1984,
+  children: 2
+});
+
+master.dispatch();

--- a/demo/graceful_exit/worker.js
+++ b/demo/graceful_exit/worker.js
@@ -1,0 +1,28 @@
+/*!
+ * pm - demo/graceful_exit/worker.js
+ * Copyright(c) 2013 fengmk2 <fengmk2@gmail.com>
+ * MIT Licensed
+ */
+
+"use strict";
+
+/**
+ * Module dependencies.
+ */
+
+var graceful = require('graceful');
+var worker = require('../../').createWorker();
+var server = require('./app');
+
+graceful({
+  server: server,
+  error: function (err) {
+    console.log('[%s] [worker:%s] error: %s', new Date(), process.pid, err.stack);
+    worker.disconnect();
+  },
+  killTimeout: 10000,
+});
+
+worker.ready(function (socket, port) {
+  server.emit('connection', socket);
+});

--- a/demo/master.js
+++ b/demo/master.js
@@ -9,6 +9,20 @@ app.on('giveup', function (name, fatals, pause) {
   console.log('Master giveup to restart "%s" process after %d times. pm will try after %d ms.', name, fatals, pause);
 });
 
+app.on('disconnect', function (worker, pid) {
+  // var w = cluster.fork();
+  console.error('[%s] [master:%s] wroker:%s disconnect! new worker:%s fork', 
+    new Date(), process.pid, worker.process.pid); //, w.process.pid);
+});
+
+app.on('fork', function () {
+  console.log('fork', arguments);
+});
+
+app.on('quit', function () {
+  console.log('quit', arguments);
+});
+
 /**
  * @ test fork error protect
  */
@@ -28,7 +42,7 @@ app.register('daemon', __dirname + '/worker/daemon.js', {
  * A http service
  */
 app.register('http', __dirname + '/worker/http.js', {
-  'listen' : [ 33749, __dirname + '/http.socket' ],
+  'listen' : [ 33749, __dirname + '/http.socket', 33750 ],
   'children' : 1
 });
 

--- a/demo/worker/http.js
+++ b/demo/worker/http.js
@@ -18,6 +18,14 @@ var s2 = require('http').createServer(function (req, res) {
       worker.broadcast('daemon', 'fatal');
       break;
 
+    case 'disconnect':
+      console.log('[worker:%s] disconnected', process.pid);
+      worker.disconnect();
+      setTimeout(function () {
+        process.exit(1);
+      }, 3000);
+      break;
+
       /*
     case 'reload':
       worker.reload('daemon');
@@ -30,6 +38,7 @@ var s2 = require('http').createServer(function (req, res) {
   res.end(JSON.stringify({
     'act' : url,
     'url' : req.url,
+    pid: process.pid,
   }));
 });
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 /* vim: set expandtab tabstop=2 shiftwidth=2 foldmethod=marker: */
 
-var master = require(__dirname + '/lib/master.js');
-var worker = require(__dirname + '/lib/worker.js');
+var libdir = process.env.PM_COV ? './lib-cov' : './lib';
+var master = require(libdir + '/master.js');
+var worker = require(libdir + '/worker.js');
 
 /**
  * Create a `Master`.

--- a/lib/child.js
+++ b/lib/child.js
@@ -3,7 +3,7 @@
 "use strict";
 
 var util = require('util');
-var fork = require('child_process').fork;
+var child_process = require('child_process');
 var CPUS = require(__dirname + '/os.js').cpusnum();
 
 var Handle = require(__dirname + '/common.js').getHandle;
@@ -16,7 +16,7 @@ var PROCESS = process;
 
 /* {{{ private function _extend() */
 var _extend = function (a, b) {
-  var a = a || {};
+  a = a || {};
   for (var i in b) {
     a[i] = b[i];
   }
@@ -38,6 +38,10 @@ MessageHandle.broadcast = function (owner, pid, data) {
   owner.emit('broadcast', data.who, data.msg, pid);
 };
 
+MessageHandle.disconnect = function (owner, pid, data) {
+  owner.emit('disconnect', pid, data);
+};
+
 exports.create = function (argv, options) {
 
   /* {{{ _options */
@@ -56,7 +60,7 @@ exports.create = function (argv, options) {
   if (!_options.listen) {
     _options.listen = [];
   } else if (!Array.isArray(_options.listen)) {
-    _options.listen = _options.listen.toString().split(',');
+    _options.listen = _options.listen.toString().split(',').filter(function (a) { return a; });
   }
   _options.listen = _options.listen.map(function (i) {
     return /^\d+$/.test(i) ? Number(i) : i;
@@ -121,10 +125,17 @@ exports.create = function (argv, options) {
   var command = argv.join(' ');
   var exepath = argv.shift();
 
+  Child.prototype.fork = function() {
+    var sub = this._fork();
+    return {
+      process: sub
+    };
+  };
+
   /* {{{ private prototype _fork() */
   Child.prototype._fork = function () {
     var _self = this;
-    var sub = fork(exepath, argv, {
+    var sub = child_process.fork(exepath, argv, {
       'cwd' : PROCESS.cwd(), 'env' : _extend({}, PROCESS.env)
     });
 
@@ -295,3 +306,8 @@ exports.create = function (argv, options) {
 
 };
 
+if (process.env.NODE_ENV === 'test') {
+  exports.mock = function (p) {
+    PROCESS = p;
+  };
+}

--- a/lib/master.js
+++ b/lib/master.js
@@ -8,7 +8,7 @@ var util = require('util');
 var Emitter = require('events').EventEmitter;
 
 var PROCESS = process;
-var CreateChild = require(__dirname + '/child.js').create;
+var child = require(__dirname + '/child.js');
 
 /* {{{ private function _normalize() */
 var _normalize  = function (name) {
@@ -88,7 +88,7 @@ exports.create = function (options) {
     var _self = this;
 
     PROCESS.on('SIGHUB',  function () {
-      _self.emit('signal', 1, 'SIGHUB')
+      _self.emit('signal', 1, 'SIGHUB');
     });
     PROCESS.on('exit',    function () {
       _self.shutdown('SIGKILL');
@@ -107,7 +107,7 @@ exports.create = function (options) {
     });
 
     PROCESS.on('SIGUSR1', function () {
-      _self.emit('signal', 30, 'SIGUSR1')
+      _self.emit('signal', 30, 'SIGUSR1');
       _self.reload();
     });
   };
@@ -130,7 +130,7 @@ exports.create = function (options) {
     }
 
     var _self = this;
-    var _pair = CreateChild(argv, options);
+    var _pair = child.create(argv, options);
     _pair.on('fork', function (pid) {
       _self.emit('fork', name, pid);
     });
@@ -145,6 +145,9 @@ exports.create = function (options) {
       if (_workers[to]) {
         _workers[to].broadcast(msg, name, pid);
       }
+    });
+    _pair.on('disconnect', function (pid, worker) {
+      _self.emit('disconnect', name, pid, worker);
     });
     _workers[name] = _pair;
 
@@ -170,6 +173,16 @@ exports.create = function (options) {
     });
   };
 
+  Master.prototype.fork = function (name) {
+    var _pair = _workers[name];
+    return _pair.fork();
+  };
+
   return new Master();
 };
 
+if (process.env.NODE_ENV === 'test') {
+  exports.mock = function (p) {
+    PROCESS = p;
+  };
+}

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -32,7 +32,7 @@ exports.create = function (options, PROCESS) {
   if ('function' === (typeof PROCESS.send)) {
     askmaster = function (type, data) {
       PROCESS.send({'type' : type, 'data' : data});
-    }
+    };
   }
 
   /**
@@ -64,8 +64,10 @@ exports.create = function (options, PROCESS) {
   };
   PROCESS.send && setInterval(heartbeat, _options.heartbeat_interval);
 
-  /* {{{ private function suicide() */
-  var suicide = function () {
+  /**
+   * Close all open lsitening handles.
+   */
+  var closeListeners = function () {
     Object.keys(_listener).forEach(function (i) {
       try {
         _listener[i].close();
@@ -73,6 +75,11 @@ exports.create = function (options, PROCESS) {
       } catch (e) {
       }
     });
+  };
+
+  /* {{{ private function suicide() */
+  var suicide = function () {
+    closeListeners();
     setTimeout(function () {
       PROCESS.exit(0);
     }, _options.terminate_timeout);
@@ -90,7 +97,7 @@ exports.create = function (options, PROCESS) {
       }
 
       if (handle && 'listen' === msg.type) {
-        var idx = msg.data;
+        var idx = msg.data; // port or sock
         if (_listener[idx]) {
           _listener[idx].close();
           delete _listener[idx];
@@ -130,7 +137,7 @@ exports.create = function (options, PROCESS) {
     askmaster('ready');
     if ('function' === (typeof callback)) {
       onconnect = callback;
-    };
+    }
   };
   /* }}} */
 
@@ -146,6 +153,17 @@ exports.create = function (options, PROCESS) {
   };
   /* }}} */
 
+  Worker.prototype.disconnect = function () {
+    var worker = {
+      suicide: true,
+      process: {
+        pid: PROCESS.pid,
+      }
+    };
+    askmaster('disconnect', worker);
+    // close listeners, do not accept new connection.
+    closeListeners();
+  };
 
   /* {{{ public prototype serialStart() */
   /**
@@ -195,9 +213,9 @@ exports.create = function (options, PROCESS) {
   };
   /* }}} */
 
-  var releaseToken = function(){
+  var releaseToken = function () {
     PROCESS.send({cmd : 'token_release'});
-  }
+  };
 
   var _me = new Worker();
 

--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
     "node": ">=0.6.9"
   },
   "devDependencies": {
+    "graceful": ">=0.0.3",
     "should": ">=0.4.2",
     "mocha": ">=0.9.0",
     "rewire": "*",
-    "visionmedia-jscoverage" : ">=1.0.0"
+    "mm": "*",
+    "jscover" : ">=0.2.4"
   },
   "main"  : "./index.js",
   "scripts": {

--- a/test/common.test.js
+++ b/test/common.test.js
@@ -5,8 +5,8 @@
 var http = require('http');
 var net = require('net');
 var should = require('should');
-
-var common = require(__dirname + '/../lib/common.js');
+var libdir = process.env.PM_COV ? '../lib-cov' : '../lib';
+var common = require(libdir + '/common.js');
 
 describe('common functions', function () {
 
@@ -14,7 +14,9 @@ describe('common functions', function () {
     should.ok(!common.getHandle('/i/am/denied.socket'));
   });
 
-  [33046, '33046', __dirname + '/a.socket'].forEach(function (idx) {
+  var sock = __dirname + '/' + process.version + '.a.socket';
+
+  [33046, '33046', sock].forEach(function (idx) {
     it('listen at: ' + idx, function (done) {
       var _me = http.createServer(function (req, res) {
         res.end(req.url);

--- a/test/master.test.js
+++ b/test/master.test.js
@@ -2,11 +2,13 @@
 
 "use strict";
 
+var mm = require('mm');
 var fs = require('fs');
-var rewire = require('rewire');
 var should = require('should');
 var common = require(__dirname + '/mock.js');
-var master = rewire(__dirname + '/../lib/master.js');
+var libdir = process.env.PM_COV ? '../lib-cov' : '../lib';
+var child = require(libdir + '/child.js');
+var master = require(libdir + '/master.js');
 
 var PROCESS;
 
@@ -19,16 +21,18 @@ describe('master', function () {
     PROCESS.__getOutMessage().should.eql([]);
     PROCESS.__getEvents().should.eql([]);
 
-    master.__set__({
-      'PROCESS' : PROCESS,
-      'CreateChild' : common.mockChild,
-    });
+    master.mock(PROCESS);
+    mm(child, 'create', common.mockChild);
 
     var cmd = require('util').format('rm -rf "%s/tmp"', __dirname);
     require('child_process').exec(cmd, function (e) {
       should.ok(!e);
       done();
     });
+  });
+
+  afterEach(function () {
+    mm.restore();
   });
 
   var pidfile = __dirname + '/tmp/a.pid';

--- a/test/os.test.js
+++ b/test/os.test.js
@@ -2,45 +2,41 @@
 
 "use strict";
 
-var rewire = require('rewire');
+var fs = require('fs');
+var mm = require('mm');
 var should = require('should');
-var os = rewire(__dirname + '/../lib/os.js');
-
-var _mocked = {};
-_mocked.os  = {
-  'platform' : function () {return 'linux';},
-  'cpus' : function () {return [0,1]},
-};
-_mocked.fs  = {
-  'readFileSync' : function () {
-    return ['cpu  1075827 37 353258 631990752 220302 11 60263 22716756 0',
-    'cpu0 504931 33 161329 100616782 159668 9 23452 7626460 0',
-    'cpu1 503828 3 173795 107652876 20966 0 26767 607430 0',
-    'cpu8 31654 0 7789 98402179 26194 1 8495 11865758 0',
-    'cpu9 16218 0 4293 107873312 3666 0 1041 1339345 0',
-    'cpu10 7757 0 3439 108714234 3819 0 311 731368 0',
-    'cpu11 11436 0 2611 108731366 5987 0 194 546393 0',
-    'intr ...'
-      ].join('\n');
-  },
-};
+var libdir = process.env.PM_COV ? '../lib-cov' : '../lib';
+var os = require(libdir + '/os.js');
 
 describe('os patch for linux', function () {
 
+  afterEach(function () {
+    mm.restore();
+  });
+
   it('should_cpusnum_works_fine', function () {
-    os.__set__(_mocked);
+    var _os = require('os');
+    mm(_os, 'platform', function () { return 'linux'; });
+    mm(_os, 'cpus', function () { return [0, 1]; });
+    mm(fs, 'readFileSync', function () {
+      return ['cpu  1075827 37 353258 631990752 220302 11 60263 22716756 0',
+      'cpu0 504931 33 161329 100616782 159668 9 23452 7626460 0',
+      'cpu1 503828 3 173795 107652876 20966 0 26767 607430 0',
+      'cpu8 31654 0 7789 98402179 26194 1 8495 11865758 0',
+      'cpu9 16218 0 4293 107873312 3666 0 1041 1339345 0',
+      'cpu10 7757 0 3439 108714234 3819 0 311 731368 0',
+      'cpu11 11436 0 2611 108731366 5987 0 194 546393 0',
+      'intr ...'
+        ].join('\n');
+    });
     os.cpusnum().should.eql(6);
 
-    _mocked.fs.readFileSync = function () {
+    mm(fs, 'readFileSync', function () {
       throw new Error('test error');
-    };
-    os.__set__(_mocked);
+    });
     os.cpusnum().should.eql(2);
 
-    _mocked.os.platform = function () {
-      return 'darwin';
-    };
-    os.__set__(_mocked);
+    mm(_os, 'platform', function () { return 'darwin'; });
     os.cpusnum().should.eql(2);
   });
 


### PR DESCRIPTION
- Support `worker.disconnect()` and `master.fork(name)` API. fixes #32
- add graceful_exit demo codes
- remove `rewire`
- use `jscover` instead of `visionmedia-jscoverage`

`rewire` 非常影响单元测试，会引入一些非预料的bug。
